### PR TITLE
Removing Whitespaces

### DIFF
--- a/about-the-data/work.md
+++ b/about-the-data/work.md
@@ -12,9 +12,9 @@ Works are linked to other works via the [`referenced_works`](work.md#referenced\
 
 There are three component objects that are only used as part of a `Work`:&#x20;
 
-* [`Authorship`](work.md#the-authorship-object)``
-* ``[`HostVenue`](work.md#the-hostvenue-object)``
-* ``[`OpenAccess`](work.md#the-openaccess-object)``
+* [`Authorship`](work.md#the-authorship-object)
+* [`HostVenue`](work.md#the-hostvenue-object)
+* [`OpenAccess`](work.md#the-openaccess-object)
 
 {% hint style="info" %}
 Most of the examples below are drawn from a single work. You can view this work in its entirety via the [website](https://openalex.org/W2741809807) or [API](https://openalex.org/W2741809807.json).


### PR DESCRIPTION
Minor whitespaces were removed for proper rendering in HTML.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/15020288/199119474-5b1d9438-c4d5-4ccb-8574-83284300f15c.png">
NOTE: The whitespace before/after the text in bullet points has been removed for a more consistent style format.