### PR TITLE
Removing minor whitespaces

### DIFF
--- a/about-the-data/author.md
+++ b/about-the-data/author.md
@@ -204,6 +204,6 @@ created_date: "2017-08-08"
 
 The `DehydratedAuthor` is stripped-down [`Author`](author.md#the-author-object) object, with most of its properties removed to save weight. Its only remaining properties are:
 
-* ``[`id`](author.md#id)``
-* [`display_name`](author.md#display\_name)``
-* [`orcid`](author.md#orcid)``
+* [`id`](author.md#id)
+* [`display_name`](author.md#display\_name)
+* [`orcid`](author.md#orcid)

--- a/about-the-data/concept.md
+++ b/about-the-data/concept.md
@@ -240,7 +240,7 @@ created_date: "2017-08-08"
 
 The `DehydratedConcept` is stripped-down [`Concept`](concept.md#the-concept-object) object, with most of its properties removed to save weight. Its only remaining properties are:
 
-* [`id`](concept.md#id)``
-* [`wikidata`](concept.md#wikidata)``
-* [`display_name`](concept.md#display\_name)``
-* [`level`](concept.md#level)``
+* [`id`](concept.md#id)
+* [`wikidata`](concept.md#wikidata)
+* [`display_name`](concept.md#display\_name)
+* [`level`](concept.md#level)

--- a/about-the-data/institution.md
+++ b/about-the-data/institution.md
@@ -303,9 +303,9 @@ created_date: "2017-08-08"
 
 The `DehydratedInstitution` is stripped-down [`Institution`](institution.md#the-institution-object) object, with most of its properties removed to save weight. Its only remaining properties are:
 
-* [`id`](institution.md#id)``
-* [`display_name`](institution.md#display\_name)``
-* [`ror`](institution.md#ror)``
-* [`country_code`](institution.md#country\_code)``
-* [`type`](institution.md#type)``
+* [`id`](institution.md#id)
+* [`display_name`](institution.md#display\_name)
+* [`ror`](institution.md#ror)
+* [`country_code`](institution.md#country\_code)
+* [`type`](institution.md#type)
 

--- a/about-the-data/venue.md
+++ b/about-the-data/venue.md
@@ -208,8 +208,8 @@ created_date: "2017-08-08"
 
 The `DehydratedVenue` is stripped-down [`Venue`](venue.md#the-venue-object) object, with most of its properties removed to save weight. Its only remaining properties are:
 
-* [`id`](venue.md#id)``
-* [`issn_l`](venue.md#issn\_l)``
-* [`issn`](venue.md#issn)``
-* [`display_name`](venue.md#display\_name)``
-* ``[`publisher`](venue.md#publisher)``
+* [`id`](venue.md#id)
+* [`issn_l`](venue.md#issn\_l)
+* [`issn`](venue.md#issn)
+* [`display_name`](venue.md#display\_name)
+* [`publisher`](venue.md#publisher)

--- a/about-the-data/work.md
+++ b/about-the-data/work.md
@@ -12,9 +12,9 @@ Works are linked to other works via the [`referenced_works`](work.md#referenced\
 
 There are three component objects that are only used as part of a `Work`:&#x20;
 
-* [`Authorship`](work.md#the-authorship-object)``
-* ``[`HostVenue`](work.md#the-hostvenue-object)``
-* ``[`OpenAccess`](work.md#the-openaccess-object)``
+* [`Authorship`](work.md#the-authorship-object)
+* [`HostVenue`](work.md#the-hostvenue-object)
+* [`OpenAccess`](work.md#the-openaccess-object)
 
 {% hint style="info" %}
 Most of the examples below are drawn from a single work. You can view this work in its entirety via the [website](https://openalex.org/W2741809807) or [API](https://openalex.org/W2741809807.json).


### PR DESCRIPTION
Minor whitespaces were removed for proper rendering in HTML.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/15020288/199119474-5b1d9438-c4d5-4ccb-8574-83284300f15c.png">
NOTE: The whitespace before/after the text in bullet points has been removed for a more consistent style format.