### PR TITLE
Fix rendering issue in Works' search filter table

### DIFF
--- a/api-entities/works/search-works.md
+++ b/api-entities/works/search-works.md
@@ -24,7 +24,7 @@ The following fields can be searched within works:
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
 | ``[`abstract.search`](filter-works.md#abstract.search)``                             | ``[`abstract_inverted_index`](work-object/#abstract\_inverted\_index)`` |
 | ``[`display_name.search`](filter-works.md#display\_name.search-alias-title.search)`` | ``[`display_name`](work-object/#display\_name)``                        |
-| ``[`fulltext.search`](filter-works.md#fulltext.search)``                             | fulltext via [`n-grams`](get-n-grams.md)``                              |
+| ``[`fulltext.search`](filter-works.md#fulltext.search)``                             | fulltext via [`n-grams`](get-n-grams.md)                                |
 | ``[`title.search`](filter-works.md#display\_name.search-alias-title.search)``        | ``[`display_name`](work-object/#display\_name)``                        |
 
 ### Why can't I search by name of related entity (author name, institution name, etc.)?


### PR DESCRIPTION
Currently, on [works/search-works](https://docs.openalex.org/api-entities/works/search-works#search-a-specific-field), two extra backticks caused the issue in rendering this table. This PR fixes the issue.

![works-search-tab](https://user-images.githubusercontent.com/1679452/229299343-867a03a9-d56f-4047-a3e9-3d53e7063b7c.png)
