### PR TITLE
Fix potential typos in api-entities

### DIFF
--- a/api-entities/authors/filter-authors.md
+++ b/api-entities/authors/filter-authors.md
@@ -62,7 +62,7 @@ Value: a Boolean (`true` or `false`)
 Returns: authors that have or lack an [orcid](author-object.md#orcid), depending on the given value.
 
 * Get the authors that have an ORCID:\
-  ``[`https://api.openalex.org/authors?filter=has_orcid:true`](https://api.openalex.org/authors?filter=has\_orcid:true)
+  [`https://api.openalex.org/authors?filter=has_orcid:true`](https://api.openalex.org/authors?filter=has\_orcid:true)
 
 #### `last_known_institution.continent`
 

--- a/api-entities/authors/get-a-single-author.md
+++ b/api-entities/authors/get-a-single-author.md
@@ -1,6 +1,6 @@
 # Get a single author
 
-It's easy to get an author from from the API with: `/authors/<entity_id>`. Here's an example:
+It's easy to get an author from the API with: `/authors/<entity_id>`. Here's an example:
 
 * Get the author with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `A2208157607`: \
   [https://api.openalex.org/authors/A2208157607](https://api.openalex.org/authors/A2208157607)

--- a/api-entities/authors/group-authors.md
+++ b/api-entities/authors/group-authors.md
@@ -3,7 +3,7 @@
 You can group authors with the `group_by` parameter:
 
 * Get counts of authors by the last known institution continent:\
-  [`https://api.openalex.org/authors?group_by=last_known_institution.continent`](https://api.openalex.org/authors?group\_by=last\_known\_institution.continent)``
+  [`https://api.openalex.org/authors?group_by=last_known_institution.continent`](https://api.openalex.org/authors?group\_by=last\_known\_institution.continent)
 
 Or you can group using one the attributes below.
 

--- a/api-entities/concepts/get-a-single-concept.md
+++ b/api-entities/concepts/get-a-single-concept.md
@@ -1,6 +1,6 @@
 # Get a single concept
 
-It's easy to get a concept from from the API with: `/concepts/<entity_id>`. Here's an example:
+It's easy to get a concept from the API with: `/concepts/<entity_id>`. Here's an example:
 
 * Get the concept with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `C71924100`: \
   [https://api.openalex.org/concepts/C71924100](https://api.openalex.org/concepts/C71924100)

--- a/api-entities/funders/get-a-single-funder.md
+++ b/api-entities/funders/get-a-single-funder.md
@@ -1,6 +1,6 @@
 # Get a single funder
 
-It's easy to get a funder from from the API with: `/funders/<entity_id>`. Here's an example:
+It's easy to get a funder from the API with: `/funders/<entity_id>`. Here's an example:
 
 * Get the funder with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `F4320332161`: \
   [https://api.openalex.org/funders/F4320332161](https://api.openalex.org/funders/F4320332161)

--- a/api-entities/institutions/get-a-single-institution.md
+++ b/api-entities/institutions/get-a-single-institution.md
@@ -1,6 +1,6 @@
 # Get a single institution
 
-It's easy to get an institution from from the API with: `/institutions/<entity_id>`. Here's an example:
+It's easy to get an institution from the API with: `/institutions/<entity_id>`. Here's an example:
 
 * Get the institution with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `I27837315`: \
   [https://api.openalex.org/institutions/I27837315](https://api.openalex.org/institutions/I27837315)

--- a/api-entities/publishers/filter-publishers.md
+++ b/api-entities/publishers/filter-publishers.md
@@ -52,7 +52,7 @@ Value: a search string
 Returns: publishers with a [`display_name`](publisher-object.md#display\_name) containing the given string; see the [search page](search-publishers.md#search-a-specific-field) for details.
 
 * Get publishers with names containing "elsevier":\
-  [`https://api.openalex.org/publishers?filter=display_name.search:elsevier`](https://api.openalex.org/publishers?filter=display\_name.search:elsevier)``
+  [`https://api.openalex.org/publishers?filter=display_name.search:elsevier`](https://api.openalex.org/publishers?filter=display\_name.search:elsevier)
 
 {% hint style="info" %}
 In most cases, you should use the [`search` parameter](search-publishers.md) instead of this filter because it uses a better search algorithm.

--- a/api-entities/publishers/get-a-single-publisher.md
+++ b/api-entities/publishers/get-a-single-publisher.md
@@ -1,6 +1,6 @@
 # Get a single publisher
 
-It's easy to get a publisher from from the API with: `/publishers/<entity_id>`. Here's an example:
+It's easy to get a publisher from the API with: `/publishers/<entity_id>`. Here's an example:
 
 * Get the publisher with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `P4310319965`: \
   [https://api.openalex.org/publishers/P4310319965](https://api.openalex.org/publishers/P4310319965)

--- a/api-entities/sources/filter-sources.md
+++ b/api-entities/sources/filter-sources.md
@@ -67,7 +67,7 @@ Value: a search string
 Returns: sources with a [`display_name`](source-object.md#display\_name) containing the given string; see the [search page](search-sources.md) for details.
 
 * Get sources with names containing "Neurology":\
-  [`https://api.openalex.org/sources?filter=display_name.search:Neurology`](https://api.openalex.org/sources?filter=display\_name.search:Neurology)``
+  [`https://api.openalex.org/sources?filter=display_name.search:Neurology`](https://api.openalex.org/sources?filter=display\_name.search:Neurology)
 
 {% hint style="info" %}
 In most cases, you should use the [`search`](search-sources.md#sources-full-search) parameter instead of this filter because it uses a better search algorithm.
@@ -80,7 +80,7 @@ Value: a Boolean (`true` or `false`)
 Returns: sources that have or lack an [ISSN](./source-object.md#issn), depending on the given value.
 
 * Get sources without ISSNs:\
-  [`https://api.openalex.org/sources?filter=has_issn:false`](https://api.openalex.org/sources?filter=has\_issn:false)``
+  [`https://api.openalex.org/sources?filter=has_issn:false`](https://api.openalex.org/sources?filter=has\_issn:false)
 
 #### `is_global_south`
 

--- a/api-entities/sources/get-a-single-source.md
+++ b/api-entities/sources/get-a-single-source.md
@@ -1,6 +1,6 @@
 # Get a single source
 
-It's easy to get a source from from the API with: `/sources/<entity_id>`. Here's an example:
+It's easy to get a source from the API with: `/sources/<entity_id>`. Here's an example:
 
 * Get the source with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `S137773608`: \
   [https://api.openalex.org/sources/S137773608](https://api.openalex.org/sources/S137773608)

--- a/api-entities/works/filter-works.md
+++ b/api-entities/works/filter-works.md
@@ -160,7 +160,7 @@ Value: the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-opena
 
 Returns: works that cite the given work. This is works that have the given OpenAlex ID in the [`referenced_works`](work-object/#referenced\_works) section. You can think of this as **incoming citations**.
 
-* Get works that cite [`https://openalex.org/W2741809807`](https://openalex.org/W2741809807): [`https://api.openalex.org/works?filter=cites:W2741809807`](https://api.openalex.org/works?filter=cites:W2741809807)\`\`
+* Get works that cite [`https://openalex.org/W2741809807`](https://openalex.org/W2741809807): [`https://api.openalex.org/works?filter=cites:W2741809807`](https://api.openalex.org/works?filter=cites:W2741809807)
 
 {% hint style="info" %}
 The number of results returned by this filter may be slightly higher than the work's[`cited_by_count`](work-object/#cited\_by\_count)due to a timing lag in updating that field.
@@ -203,7 +203,7 @@ Returns: works with [`created_date`](work-object/#created\_date) greater than or
 This field requires an [OpenAlex Premium subscription to access. Click here to learn more.](https://openalex.org/pricing)
 
 * Get works created on or _after_ January 12th, 2023 (does not work without valid API key):\
-  [`https://api.openalex.org/works?filter=from_created_date:2023-01-12&api_key=myapikey`](https://api.openalex.org/works?filter=from\_created\_date:2023-01-12\&api\_key=myapikey)\`\`
+  [`https://api.openalex.org/works?filter=from_created_date:2023-01-12&api_key=myapikey`](https://api.openalex.org/works?filter=from\_created\_date:2023-01-12\&api\_key=myapikey)
 
 #### `from_publication_date`
 
@@ -239,7 +239,7 @@ Value: a search string
 
 Returns: works whose fulltext includes the given string. Fulltext search is powered by an index of word sequences called n-grams - see [Get N-grams](get-n-grams.md) for coverage details.
 
-* Get works with fulltext that mention "climate change": [`https://api.openalex.org/works?filter=fulltext.search:climate%20change`](https://api.openalex.org/works?filter=fulltext.search:climate%20change)\`\`
+* Get works with fulltext that mention "climate change": [`https://api.openalex.org/works?filter=fulltext.search:climate%20change`](https://api.openalex.org/works?filter=fulltext.search:climate%20change)
 
 {% hint style="info" %}
 We combined some n-grams before storing them in our search database, so querying for an exact phrase using quotes does not always work well.
@@ -261,7 +261,7 @@ Value: a Boolean (`true` or `false`)
 Returns: works that have or lack a DOI, depending on the given value. It's especially useful for [grouping](group-works.md).
 
 * Get the works that have no DOI assigned:\
-  [`https://api.openalex.org/works?filter=has_doi:false`](https://api.openalex.org/works?filter=has\_doi:false) \`\`
+  [`https://api.openalex.org/works?filter=has_doi:false`](https://api.openalex.org/works?filter=has\_doi:false) 
 
 #### `has_oa_accepted_or_published_version`
 
@@ -279,7 +279,7 @@ Value: a Boolean (`true` or `false`)
 Returns: works with at least one of the [`locations`](work-object/#locations) has [`is_oa`](work-object/#is\_oa)= true and [`version`](work-object/#version) is submittedVersion. This is useful for finding works with preprints deposited somewhere.
 
 * Get works with an OA submitted copy:\
-  [`https://api.openalex.org/works?filter=has_oa_submitted_version:true`](https://api.openalex.org/works?filter=has\_oa\_submitted\_version:true)\`\`
+  [`https://api.openalex.org/works?filter=has_oa_submitted_version:true`](https://api.openalex.org/works?filter=has\_oa\_submitted\_version:true)
 
 #### `has_orcid`
 
@@ -288,7 +288,7 @@ Value: a Boolean (`true` or `false`)
 Returns: if `true` it returns works where at least one author or has an [ORCID ID](work-object/#ids). If `false`, it returns works where no authors have an ORCID ID. This is based on the `orcid` field within [`authorships.author`](work-object/#author).
 
 * Get the works where at least one author has an ORCID ID:\
-  [`https://api.openalex.org/works?filter=has_orcid:true`](https://api.openalex.org/works?filter=has\_orcid:true) \`\`
+  [`https://api.openalex.org/works?filter=has_orcid:true`](https://api.openalex.org/works?filter=has\_orcid:true) 
 
 #### `has_pmcid`
 
@@ -297,7 +297,7 @@ Value: a Boolean (`true` or `false`)
 Returns: works that have or lack a PubMed Central identifier ([`pmcid`](work-object/#ids)) depending on the given value.
 
 * Get the works that have a `pmcid`:\
-  [`https://api.openalex.org/works?filter=has_pmcid:true`](https://api.openalex.org/works?filter=has\_pmcid:true)\`\`
+  [`https://api.openalex.org/works?filter=has_pmcid:true`](https://api.openalex.org/works?filter=has\_pmcid:true)
 
 #### `has_pmid`
 
@@ -306,7 +306,7 @@ Value: a Boolean (`true` or `false`)
 Returns: works that have or lack a PubMed identifier ([`pmid`](../authors/author-object.md#ids)), depending on the given value.
 
 * Get the works that have a `pmid`:\
-  [`https://api.openalex.org/works?filter=has_pmid:true`](https://api.openalex.org/works?filter=has\_pmid:true)\`\`
+  [`https://api.openalex.org/works?filter=has_pmid:true`](https://api.openalex.org/works?filter=has\_pmid:true)
 
 #### `has_ngrams`
 
@@ -374,7 +374,7 @@ Value: a search string
 
 Returns: works that have at least one [`raw_affiliation_string`](work-object/#raw\_affiliation\_string) which includes the given string. See the [search page](../../how-to-use-the-api/get-lists-of-entities/search-entities.md) for details on the search algorithm used.
 
-* Get works with the words _Department of Political Science, University of Amsterdam_ somewhere in at least one author's `raw_affiliation_string`: [`https://api.openalex.org/works?filter=raw_affiliation_string.search:department%20of%20political%20science%20university%20of%amsterdam`](https://api.openalex.org/works?filter=raw\_affiliation\_string.search:department%20of%20political%20science%20university%20of%20amsterdam)\`\`
+* Get works with the words _Department of Political Science, University of Amsterdam_ somewhere in at least one author's `raw_affiliation_string`: [`https://api.openalex.org/works?filter=raw_affiliation_string.search:department%20of%20political%20science%20university%20of%amsterdam`](https://api.openalex.org/works?filter=raw\_affiliation\_string.search:department%20of%20political%20science%20university%20of%20amsterdam)
 
 #### `related_to`
 
@@ -409,7 +409,7 @@ Value: a date, formatted as `yyyy-mm-dd`
 Returns: works with [`publication_date`](work-object/#publication\_date) less than or equal to the given date.
 
 * Get works published on or _before_ March 14th, 2001:\
-  [`https://api.openalex.org/works?filter=to_publication_date:2001-03-14`](https://api.openalex.org/works?filter=to\_publication\_date:2001-03-14)\`\`
+  [`https://api.openalex.org/works?filter=to_publication_date:2001-03-14`](https://api.openalex.org/works?filter=to\_publication\_date:2001-03-14)
 
 #### `version`
 

--- a/api-entities/works/get-a-single-work.md
+++ b/api-entities/works/get-a-single-work.md
@@ -1,6 +1,6 @@
 # Get a single work
 
-It's easy to get a work from from the API with: `/works/<entity_id>` Here's an example:
+It's easy to get a work from the API with: `/works/<entity_id>` Here's an example:
 
 * Get the work with the [OpenAlex ID](../../how-to-use-the-api/get-single-entities/#the-openalex-id) `W2741809807`: [`https://api.openalex.org/works/W2741809807`](https://api.openalex.org/works/W2741809807)
 

--- a/how-to-use-the-api/get-lists-of-entities/README.md
+++ b/how-to-use-the-api/get-lists-of-entities/README.md
@@ -1,6 +1,6 @@
 # Get lists of entities
 
-It's easy to get a list of entity objects from from the API:`/<entity_name>.` Here's an example:
+It's easy to get a list of entity objects from the API:`/<entity_name>.` Here's an example:
 
 * Get a list of _all_ the concepts in OpenAlex:\
   [`https://api.openalex.org/concepts`](https://api.openalex.org/concepts)

--- a/how-to-use-the-api/get-lists-of-entities/filter-entity-lists.md
+++ b/how-to-use-the-api/get-lists-of-entities/filter-entity-lists.md
@@ -7,7 +7,7 @@ A list of filters are set using the `filter` parameter,  formatted like this: `f
 * Get the works whose [type](../../api-entities/works/work-object/#type) is `book`:\
   [`https://api.openalex.org/works?filter=type:book`](https://api.openalex.org/works?filter=type:book)
 * Get the authors whose name is Einstein:\
-  [`https://api.openalex.org/authors?filter=display_name.search:einstein`](https://api.openalex.org/authors?filter=display\_name.search:einstein)``
+  [`https://api.openalex.org/authors?filter=display_name.search:einstein`](https://api.openalex.org/authors?filter=display\_name.search:einstein)
 
 Filters are case-insensitive.&#x20;
 
@@ -30,28 +30,28 @@ Some attributes have special filters that act as syntactic sugar around commonly
 You can negate any filter, numerical or otherwise, by prepending the exclamation mark symbol (`!`) to the filter value. Example:
 
 * Get all institutions _except_ for ones located in the US:\
-  [`https://api.openalex.org/institutions?filter=country_code:!us`](https://api.openalex.org/institutions?filter=country\_code:!us)``
+  [`https://api.openalex.org/institutions?filter=country_code:!us`](https://api.openalex.org/institutions?filter=country\_code:!us)
 
 ### Intersection (AND)
 
 By default, the returned result set includes only records that satisfy _all_ the supplied filters. In other words, filters are combined as an AND query. Example:
 
 * Get all works that have been cited more than once _and_ are free to read:\
-  [`https://api.openalex.org/works?filter=cited_by_count:>1,is_oa:true`](https://api.openalex.org/works?filter=cited\_by\_count:%3E1,is\_oa:true)``
+  [`https://api.openalex.org/works?filter=cited_by_count:>1,is_oa:true`](https://api.openalex.org/works?filter=cited\_by\_count:%3E1,is\_oa:true)
 * Get all the works that have an author from France _and_ an author from the UK:\
-  [`https://api.openalex.org/works?filter=institutions.country_code:fr,institutions.country_code:gb`](https://api.openalex.org/works?filter=institutions.country\_code:fr,institutions.country\_code:gb)``
+  [`https://api.openalex.org/works?filter=institutions.country_code:fr,institutions.country_code:gb`](https://api.openalex.org/works?filter=institutions.country\_code:fr,institutions.country\_code:gb)
 
 You can repeat a filter to create an AND query within a single attribute. Example:
 
 * Get all works that have concepts "Medicine" _and_ "Artificial Intelligence":\
-  [`https://api.openalex.org/works?filter=concepts.id:C71924100,concepts.id:C154945302`](https://api.openalex.org/works?filter=concepts.id:C71924100,concepts.id:C154945302)``
+  [`https://api.openalex.org/works?filter=concepts.id:C71924100,concepts.id:C154945302`](https://api.openalex.org/works?filter=concepts.id:C71924100,concepts.id:C154945302)
 
 ### Addition (OR)
 
 Use the pipe symbol (`|`) to input lists of values such that _any_ of the values can be satisfied--in other words, when you separate filter values with a pipe, they'll be combined as an `OR` query. Example:
 
 * Get all the works that have an author from France or an author from the UK:\
-  [`https://api.openalex.org/works?filter=institutions.country_code:fr|gb`](https://api.openalex.org/works?filter=institutions.country\_code:fr|gb)``
+  [`https://api.openalex.org/works?filter=institutions.country_code:fr|gb`](https://api.openalex.org/works?filter=institutions.country\_code:fr|gb)
 
 This is particularly useful when you want to retrieve a many records by ID all at once. Instead of making a whole bunch of singleton calls in a loop, you can make one call, like this:
 
@@ -64,7 +64,7 @@ You can combine up to 50 values for a given filter in this way. See our [blog po
 You can use OR for values _within_ a given filter, but not _between_ different filters. So this, for example, **doesn't work and will return an error**:&#x20;
 
 * Get either French works _or_ ones published in the journal with ISSN 0957-1558:\
-  [`https://api.openalex.org/works?filter=institutions.country_code:fr|primary_location.source.issn:0957-1558`](https://api.openalex.org/works?filter=institutions.country\_code:fr|primary\_location.source.issn:0957-1558)``
+  [`https://api.openalex.org/works?filter=institutions.country_code:fr|primary_location.source.issn:0957-1558`](https://api.openalex.org/works?filter=institutions.country\_code:fr|primary\_location.source.issn:0957-1558)
 {% endhint %}
 
 ## Available Filters

--- a/how-to-use-the-api/get-single-entities/README.md
+++ b/how-to-use-the-api/get-single-entities/README.md
@@ -6,7 +6,7 @@ description: Get a single entity, based on an ID
 
 This is a more detailed guide to single entities in OpenAlex. If you're just getting started, check out [get a single work](../../api-entities/works/get-a-single-work.md).
 
-It's easy to get a singleton entity object from from the API:`/<entity_name>/<entity_id>.` Here's an example:
+It's easy to get a singleton entity object from the API:`/<entity_name>/<entity_id>.` Here's an example:
 
 * Get the work with the [OpenAlex ID](./#the-openalex-id) `W2741809807`: [`https://api.openalex.org/works/W2741809807`](https://api.openalex.org/works/W2741809807)
 


### PR DESCRIPTION
There seems to have extra 'from's in the documentation in each entity. This PR remove all the extra "from"

Thanks for this great work!