### PR TITLE
add funder to possible values for institution type

### DIFF
--- a/api-entities/institutions/institution-object.md
+++ b/api-entities/institutions/institution-object.md
@@ -310,7 +310,7 @@ summary_stats: {
 
 _String:_ The institution's primary type, using the [ROR "type" controlled vocabulary](https://ror.readme.io/docs/ror-data-structure).
 
-Possible values are: `Education`, `Healthcare`, `Company`, `Archive`, `Nonprofit`, `Government`, `Facility`, and `Other`.
+Possible values are: `Education`, `Funder`, `Healthcare`, `Company`, `Archive`, `Nonprofit`, `Government`, `Facility`, and `Other`.
 
 ```json
 type: "education"


### PR DESCRIPTION
fixes #25 

### Status quo
OpenAlex docs for the institution object and its types lists

> Possible values are: Education, Healthcare, Company, Archive, Nonprofit, Government, Facility, and Other

while the linked ROR types consist of

> Allowed types are education, funder, healthcare, company, archive, nonprofit, government, facility, and other.

--> In OpenAlex docs the type "funder" is missing

### Proposed changes
This PR adds "funder" to the list of possible values for institution type.